### PR TITLE
Switch Attribute creation to use `AttributeModifierSlot.HAND` 

### DIFF
--- a/src/main/java/net/fabric_extras/ranged_weapon/client/RangedWeaponAPIClient.java
+++ b/src/main/java/net/fabric_extras/ranged_weapon/client/RangedWeaponAPIClient.java
@@ -10,7 +10,7 @@ public class RangedWeaponAPIClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ItemTooltipCallback.EVENT.register((stack, tooltipContext, tooltipType, lines) -> {
-            TooltipHelper.updateTooltipText(stack, lines);
+            //TooltipHelper.updateTooltipText(stack, lines);
         });
         // Calling these from MinecraftClient run, so all mod registrations are done
 //        for (var bow: CustomBow.instances) {

--- a/src/main/java/net/fabric_extras/ranged_weapon/client/TooltipHelper.java
+++ b/src/main/java/net/fabric_extras/ranged_weapon/client/TooltipHelper.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TooltipHelper {
+    /*
     public static void updateTooltipText(ItemStack itemStack, List<Text> lines) {
         if (itemStack.getItem() instanceof CustomRangedWeapon) {
             mergeAttributeLines_MainHandOffHand(lines);
@@ -18,6 +19,7 @@ public class TooltipHelper {
     }
 
     private static void mergeAttributeLines_MainHandOffHand(List<Text> tooltip) {
+
         List<Text> heldInHandLines = new ArrayList<>();
         List<Text> mainHandAttributes = new ArrayList<>();
         List<Text> offHandAttributes = new ArrayList<>();
@@ -65,7 +67,10 @@ public class TooltipHelper {
                 tooltip.remove(lastIndex);
             }
         }
+
     }
+
+     */
 
 //    private static void replaceAttributeLines_BlueWithGreen(List<Text> tooltip) {
 //        var attributeTranslationKey = EntityAttributes_RangedWeapon.DAMAGE.translationKey;

--- a/src/main/java/net/fabric_extras/ranged_weapon/mixin/item/RangedWeaponItemMixin.java
+++ b/src/main/java/net/fabric_extras/ranged_weapon/mixin/item/RangedWeaponItemMixin.java
@@ -52,22 +52,12 @@ abstract class RangedWeaponItemMixin extends Item implements CustomRangedWeapon 
                 .add(
                         EntityAttributes_RangedWeapon.DAMAGE.entry,
                         damage,
-                        AttributeModifierSlot.MAINHAND
-                )
-                .add(
-                        EntityAttributes_RangedWeapon.DAMAGE.entry,
-                        damage,
-                        AttributeModifierSlot.OFFHAND
+                        AttributeModifierSlot.HAND
                 )
                 .add(
                         EntityAttributes_RangedWeapon.PULL_TIME.entry,
                         pullTime,
-                        AttributeModifierSlot.MAINHAND
-                )
-                .add(
-                        EntityAttributes_RangedWeapon.PULL_TIME.entry,
-                        pullTime,
-                        AttributeModifierSlot.OFFHAND
+                        AttributeModifierSlot.HAND
                 );
 
         if (config.velocity_bonus() > 0) {
@@ -79,11 +69,7 @@ abstract class RangedWeaponItemMixin extends Item implements CustomRangedWeapon 
                 .add(
                         EntityAttributes_RangedWeapon.VELOCITY.entry,
                         velocity,
-                        AttributeModifierSlot.MAINHAND
-                ).add(
-                        EntityAttributes_RangedWeapon.VELOCITY.entry,
-                        velocity,
-                        AttributeModifierSlot.OFFHAND
+                        AttributeModifierSlot.HAND
                 );
         }
 


### PR DESCRIPTION
### Overview:

Currently, Ranged Weapon API creates duplicate modifiers for `AttributeModifierSlot.MAINHAND` and `AttributeModifierSlot.OFFHAND`, using the same identifier for both, presumably to:
1. Allow either mainhand or offhand bonuses for vanilla parity, and 
2. Shares the identifier to rely on Vanilla to deduplicate them, preventing players dual-wielding bows to get nonsensical attribute bonuses

It then manually merges the mainhand and offhand *tooltip* sections into one category, and applies a custom tooltip header for "When Held:" 

___

### What's the problem? 
Well, vanilla essentially already provides this logic for us with the `AttributeModifierSlot.HAND`. No need to reinvent the wheel here. 

This PR:
- Replaces the addition to both slots on bow construction with a single call to `AttributeModifierSlot.HAND` for each relevant attribute
- Disables (just commented out for now) tooltip merging, as it's no longer needed. 

*Vanilla translates this group as `When in Hand:`, so if that's not preferable, we could still modify *that* header to match RWAPI's `When Held:`*

___ 

I've tested and confirmed that the underlying modifier logic is still as desired:

If you have a bow in both hands, your attribute value will *read* (with the `/attribute` command) as if it's being provided the higher value between the two, but the actual *values used* will favor the mainhand (the actual bow that gets drawn). 


*(This PR also fixes a bug introduced by Thermoo, caused by them deduplicating identical modifiers on attribute construction)* 